### PR TITLE
Revert "Update dependency cryptography to v46 [SECURITY]"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ backoff==2.2.1
 certifi==2025.8.3
 cffi==1.17.1
 charset-normalizer==3.4.7
-cryptography==46.0.7
+cryptography==45.0.6
 gql==3.5.3
 graphql-core==3.2.8
 idna==3.10


### PR DESCRIPTION
Reverts open-telemetry/.roadmap#32

This is causing https://github.com/open-telemetry/.roadmap/actions/runs/25674454957/job/75368301427